### PR TITLE
Change metabase buildpack to Scalingo managed buildpack

### DIFF
--- a/.buildpacks
+++ b/.buildpacks
@@ -1,2 +1,2 @@
 https://github.com/Scalingo/buildpack-jvm-common.git
-https://github.com/betagouv/metabase-buildpack.git
+https://github.com/Scalingo/metabase-buildpack.git


### PR DESCRIPTION
By default, it install the last version and you can choose the version with [METABASE_VERSION](https://github.com/Scalingo/metabase-buildpack#metabase_version)